### PR TITLE
fix: do not segfault if docker host is not accessible

### DIFF
--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 	"time"
 
@@ -154,6 +155,7 @@ func (c Service) IsZero() bool {
 func (s *Scan) Merge(newCfg Scan) {
 	if !newCfg.Containers.Config.IsZero() {
 		s.Containers.Config = newCfg.Containers.Config
+		fixContainersConfig(s.Containers.Config)
 	}
 	if !newCfg.Filesystem.IsZero() {
 		s.Filesystem = newCfg.Filesystem
@@ -295,6 +297,7 @@ func LoadConfig(r io.Reader) (Config, error) {
 	if err := loadConfig1(r, &ret, cueConfig); err != nil {
 		return ret, err
 	}
+	fixContainersConfig(ret.Containers.Config)
 	return ret, nil
 }
 
@@ -303,6 +306,7 @@ func LoadConfigFromPath(path string) (Config, error) {
 	if err := loadConfigFromFile1(path, &ret, cueConfig); err != nil {
 		return ret, err
 	}
+	fixContainersConfig(ret.Containers.Config)
 	return ret, nil
 }
 
@@ -313,6 +317,7 @@ func LoadScanConfig(r io.Reader) (Scan, error) {
 	if err := loadConfig1(r, &ret, cueScan); err != nil {
 		return ret, err
 	}
+	fixContainersConfig(ret.Containers.Config)
 	return ret, nil
 }
 
@@ -321,6 +326,7 @@ func LoadScanConfigFromPath(path string) (Scan, error) {
 	if err := loadConfigFromFile1(path, &ret, cueScan); err != nil {
 		return ret, err
 	}
+	fixContainersConfig(ret.Containers.Config)
 	return ret, nil
 }
 
@@ -482,32 +488,46 @@ func containerConfig(ctx context.Context, typ string, sockPath string) (Containe
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	sockPath = os.ExpandEnv(sockPath)
-	if err := probeDockerLikeSocket(ctx, sockPath); err != nil {
+	realHost, err := probeDockerLikeSocket(ctx, sockPath)
+	if err != nil {
 		return ContainerConfig{}, err
 	}
 	return ContainerConfig{
 		Name:   typ,
 		Type:   typ,
-		Host:   sockPath,
+		Host:   realHost,
 		Images: []string{},
 	}, nil
 }
 
-func probeDockerLikeSocket(ctx context.Context, sockPath string) error {
-	// Build host URL
-	var host string
-	if !strings.Contains(sockPath, "://") {
-		host = "unix://" + sockPath
-	} else {
-		host = sockPath
+func fixDockerHost(sockPath string) string {
+	// Only apply unix:// prefix on Unix-like systems
+	if runtime.GOOS == "windows" {
+		return sockPath
 	}
+	if strings.HasPrefix(sockPath, "/") && !strings.Contains(sockPath, "://") {
+		return "unix://" + sockPath
+	}
+	return sockPath
+}
+
+func fixContainersConfig(configs ContainersConfig) {
+	for idx := range configs {
+		host := configs[idx].Host
+		configs[idx].Host = fixDockerHost(host)
+	}
+}
+
+func probeDockerLikeSocket(ctx context.Context, sockPath string) (string, error) {
+	// Build host URL
+	var host = fixDockerHost(sockPath)
 
 	cli, err := client.NewClientWithOpts(
 		client.WithHost(host),
 		client.WithAPIVersionNegotiation(), // negotiate highest mutually supported
 	)
 	if err != nil {
-		return fmt.Errorf("new client: %w", err)
+		return "", fmt.Errorf("new client: %w", err)
 	}
 	defer func() { _ = cli.Close() }()
 
@@ -515,12 +535,12 @@ func probeDockerLikeSocket(ctx context.Context, sockPath string) error {
 		// Distinguish dial errors
 		var netErr net.Error
 		if errors.As(err, &netErr) && netErr.Timeout() {
-			return fmt.Errorf("ping timeout: %w", err)
+			return "", fmt.Errorf("ping timeout: %w", err)
 		}
-		return fmt.Errorf("ping failed: %w", err)
+		return "", fmt.Errorf("ping failed: %w", err)
 	}
 
-	return nil
+	return host, nil
 }
 
 func isZero[T any](v T) bool {

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,6 +18,10 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not supported on Windows")
+	}
+
 	var testCases = []struct {
 		scenario     string
 		yml          string
@@ -32,7 +37,8 @@ service:
   repository:
     base_url: https://example.com/repo
 `,
-			expectedJSON: `{
+			expectedJSON: `
+				{
 				"version": 0,
 				"service": {
 					"mode": "manual",
@@ -99,6 +105,45 @@ service:
 					"ipv6": false
 				}
 			}`,
+		},
+		{
+			scenario: "fix docker socket",
+			yml: `
+version: 0
+service:
+  mode: manual
+  log: stderr
+containers:
+  enabled: true
+  config:
+    - name: docker
+      type: docker
+      host: /var/run/docker.sock
+`,
+			expectedJSON: `{
+"containers": {
+    "Config": [
+      {
+        "host": "unix:///var/run/docker.sock",
+        "name": "docker",
+        "type": "docker"
+      }
+    ],
+    "enabled": true
+  },
+  "filesystem": {
+    "enabled": false
+  },
+  "ports": {
+    "enabled": false,
+    "ipv4": false,
+    "ipv6": false
+  },
+  "service": {
+    "log": "stderr",
+    "mode": "manual"
+  },
+  "version": 0}`,
 		},
 	}
 

--- a/internal/walk/image.go
+++ b/internal/walk/image.go
@@ -71,12 +71,13 @@ func Images(parentContext context.Context, configs model.ContainersConfig) iter.
 			ctx := log.ContextAttrs(parentContext, slog.String("host", cc.Host))
 			cli, err := newClient(ctx, cc)
 			if err != nil {
-				slog.WarnContext(ctx, "can't connect, skipping", "error", err)
+				slog.WarnContext(ctx, "can't connect to container host, skipping", "error", err)
 				if !yield(nil, err) {
 					return
 				}
+				continue
 			}
-			slog.DebugContext(ctx, "connected")
+			slog.DebugContext(ctx, "connected to container host")
 			defer func() {
 				if cli != nil {
 					_ = cli.Close()

--- a/internal/walk/image_test.go
+++ b/internal/walk/image_test.go
@@ -1,0 +1,29 @@
+package walk_test
+
+import (
+	"testing"
+
+	"github.com/CZERTAINLY/Seeker/internal/model"
+	"github.com/CZERTAINLY/Seeker/internal/walk"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongHost(t *testing.T) {
+	config := model.ContainerConfig{
+		Name: t.Name(),
+		Type: "docker",
+		// no unix:// prefix, but this won't be a valid path anyway
+		Host:   "#!var/run/not-a-docker.sock",
+		Images: nil,
+	}
+
+	// the goal of this test is to not segfault😃
+	idx := 0
+	for entry, err := range walk.Images(t.Context(), []model.ContainerConfig{config}) {
+		require.Nil(t, entry)
+		require.Error(t, err)
+		idx++
+	}
+	require.Equal(t, 1, idx)
+}


### PR DESCRIPTION
Additionally it adds the `unix://` prefix to absolute paths like `/var/run/docker.sock` on !windows systems.